### PR TITLE
add a setting for fetching unread articles only

### DIFF
--- a/qml/harbour-linksbag.qml
+++ b/qml/harbour-linksbag.qml
@@ -120,7 +120,12 @@ ApplicationWindow {
         property int statusFilter: LinksBag.AllStatus
         property int contentTypeFilter: LinksBag.AllContentType
         property bool wifiOnlyDownloader: false
+        property bool unreadOnlyDownloader: false
         property bool offlineDownloader: false
+
+        onUnreadOnlyDownloaderChanged: {
+            linksbagManager.handleUnreadOnlyDownloaderChanged(unreadOnlyDownloader)
+        }
 
         onWifiOnlyDownloaderChanged: {
             linksbagManager.handleWifiOnlyDownloaderChanged(wifiOnlyDownloader)

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -252,7 +252,7 @@ Page {
                 text: qsTr("Download articles for offline reading")
                 description: qsTr("Downloaded: %L1/%L2")
                     .arg(linksbagManager.downloadedBookmarksCount)
-                    .arg(linksbagManager.bookmarksModel.count)
+                    .arg(linksbagManager.downloaderQueueSize)
                 checked: mainWindow.settings.offlineDownloader
                 onCheckedChanged: {
                     mainWindow.settings.offlineDownloader = checked
@@ -266,6 +266,16 @@ Page {
                 checked: offlineDownloaderSwitch.checked && mainWindow.settings.wifiOnlyDownloader
                 onCheckedChanged: {
                     mainWindow.settings.wifiOnlyDownloader = checked
+                    mainWindow.settings.sync()
+                }
+            }
+
+            TextSwitch {
+                text: qsTr("Download only unread")
+                enabled: offlineDownloaderSwitch.checked
+                checked: offlineDownloaderSwitch.checked && mainWindow.settings.unreadOnlyDownloader
+                onCheckedChanged: {
+                    mainWindow.settings.unreadOnlyDownloader = checked
                     mainWindow.settings.sync()
                 }
             }

--- a/src/linksbagmanager.h
+++ b/src/linksbagmanager.h
@@ -68,6 +68,7 @@ class LinksBagManager : public QObject
 
     OfflineDownloader *m_OfflineDownloader;
     QThread *m_OfflineDownloaderThread;
+    int m_OfflineDownloaderQueueSize;
 
     Q_PROPERTY(bool busy READ GetBusy NOTIFY busyChanged)
     Q_PROPERTY(bool logged READ GetLogged NOTIFY loggedChanged)
@@ -79,6 +80,8 @@ class LinksBagManager : public QObject
             NOTIFY coverModelChanged)
     Q_PROPERTY(int downloadedBookmarksCount READ GetDownloadedBookmarksCount
             NOTIFY downloadedBookmarksCountChanged)
+    Q_PROPERTY(int downloaderQueueSize READ GetDownloaderQueueSize
+            NOTIFY downloaderQueueSizeChanged)
 
     explicit LinksBagManager(QObject *parent = 0);
 public:
@@ -91,6 +94,7 @@ public:
     FilterProxyModel* GetDownloadingModel() const;
     FilterProxyModel* GetCoverModel() const;
     int GetDownloadedBookmarksCount() const;
+    int GetDownloaderQueueSize() const;
 
     void Stop();
 private:
@@ -101,6 +105,7 @@ private:
 private slots:
     void thumbnailReceived(QNetworkReply* pReply);
 
+    void handleUpdateBookmarkCount();
     void handleUpdateArticleContent(const QString& id, const QString& pubDate, const QString& content);
     void handleUpdateImageContent(const QString& id, const QImage& imageContent);
 
@@ -111,6 +116,7 @@ public slots:
     void filterBookmarks(const QString& text);
 
     void loadBookmarksFromCache();
+    void updateOfflineDownloaderQueue();
     void saveBookmarks();
     void refreshBookmarks();
     void removeBookmark(const QString& id);
@@ -136,6 +142,7 @@ public slots:
 
     void restartSyncTimer();
 
+    void handleUnreadOnlyDownloaderChanged(bool unreadOnly);
     void handleWifiOnlyDownloaderChanged(bool wifiOnly);
     void handleOfflineyDownloaderChanged(bool offlineDownloader);
 
@@ -155,7 +162,9 @@ signals:
 
     void offlineDownloaderEnabled(bool enabled);
     void wifiOnlyDownloaderEnabled(bool enabled);
+    void unreadOnlyDownloaderEnabled(bool enabled);
 
     void downloadedBookmarksCountChanged();
+    void downloaderQueueSizeChanged();
 };
 } // namespace LinskBag

--- a/src/offlinedownloader.h
+++ b/src/offlinedownloader.h
@@ -53,8 +53,10 @@ class OfflineDownloader : public QObject
     QPointer<QNetworkReply> m_CurrentReply;
     bool m_OfflineDownloader;
     bool m_WifiOnlyDownloader;
+    bool m_UnreadOnlyDownloader;
     bool m_IsOnline;
     bool m_IsWifi;
+    int m_QueueSize;
 
 public:
     static QString MercuryApiKey;
@@ -62,6 +64,7 @@ public:
     explicit OfflineDownloader();
     ~OfflineDownloader();
 
+    int GetBookmarkCount();
     Q_INVOKABLE void SetBookmarks(const Bookmarks_t& bookmarks);
 
 private:
@@ -74,6 +77,7 @@ public slots:
 
     void handleWifiOnlyDownloaderEnabled(bool wifiOnly);
     void handleOfflineDownloaderEnabled(bool offlineDownloader);
+    void handleUnreadOnlyDownloaderEnabled(bool unreadOnly);
 
 private slots:
     void handleOnlineStateChanged(bool isOnline);
@@ -86,6 +90,8 @@ private slots:
     void updateWifiState();
 
 signals:
+    void queueNeedsRefresh();
+    void updateBookmarkCount();
     void updateArticleContent(const QString& id, const QString& pubDate, const QString& content);
     void updateImageContent(const QString& id, const QImage& imageContent);
 };


### PR DESCRIPTION
Self-explanatory, I have over 2k articles archived on my Pocket account, but what I usually want to have available in offline mode are the new, unread ones.

There is a bit of a UI glitch, if you have something that isn't unread cached, the number in settings would look dumb.